### PR TITLE
Add RFC Links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,7 +21,7 @@
 title: New Relic - Developer Toolkit
 email: opensource@newrelic.com
 description: >- # this means to ignore newlines until "baseurl:"
-  The New Relic Developer Toolkit is suite of tools expressly built to ease the configuration,
+  The New Relic Developer Toolkit is a suite of tools expressly built to ease the configuration,
   management, and usage of New Relic through automation.
 baseurl: "/developer-toolkit" # the subpath of your site, e.g. /blog
 url: "https://newrelic.github.io" # the base hostname & protocol for your site, e.g. http://example.com

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -2,10 +2,10 @@
 layout: home
 ---
 
-The New Relic Developer Toolkit is suite of tools expressly built to ease the configuration, management, and usage of New Relic through automation.  This repo serves as a central location for you to discover the tools currently available, see what's being worked on right now, and provide feedback.
+The New Relic Developer Toolkit is a suite of tools expressly built to ease the configuration, management, and usage of New Relic through automation.  This repo serves as a central location for you to discover the tools currently available, see what's being worked on right now, and provide feedback.
 
 * General Resources
-  * [Roadmap](/roadmap/) - Current and future work priorities
+  * [Roadmap](roadmap/) - Current and future work priorities
   * [Kanban Board](https://github.com/orgs/newrelic/projects/6) - Current work across all tools
 * Tools in the Toolkit
   * [New Relic Terraform Provider](#new-relic-terraform-provider)

--- a/docs/roadmap.markdown
+++ b/docs/roadmap.markdown
@@ -13,16 +13,18 @@ roadmap for success.
 
 ### Get Involved
 
-In the future, we will establish a [Request for Comments](https://en.wikipedia.org/wiki/Request_for_Comments) process
-as the channel for driving this roadmap. Currently, we are using GitHub to
-communicate with the community and represent a source of truth. Please use the
-following tools to contribute:
-
+* [Roadmap RFC](https://discuss.newrelic.com/t/rfc-developer-toolkit-roadmap-2020/90528) -
+  We have established a discussion board, as part of our
+  [Request for Comments](https://en.wikipedia.org/wiki/Request_for_Comments) process
+  for driving this roadmap.
+* [Discussion Forum](https://discuss.newrelic.com/c/build-on-new-relic/developer-toolkit) -
+  Ask questions about tools within the Developer Toolkit, or help answer
+  questions from feloow community members.
 * [Issues](https://github.com/newrelic/developer-toolkit/issues) - The
   easiest way to get involved is to identify a need, and report it as an issue
   on this GitHub repo.
 * [Pull Requests](https://github.com/newrelic/developer-toolkit/pulls) - Want
-  to directly contribue? Open a PR to add some documentation, fix a grammatical
+  to directly contribute? Open a PR to add some documentation, fix a grammatical
   error, or add a feature to the backlog. Community review of PRs in-flight are
   also more than welcome!
 


### PR DESCRIPTION
Add a link to the New Relic discussion forum for soliciting feedback on the roadmap as part of the RFC process.  Also fix two minor bugs on the main page.